### PR TITLE
Fix number of chunks

### DIFF
--- a/bstrings/Program.cs
+++ b/bstrings/Program.cs
@@ -532,7 +532,7 @@ internal class Program
             long offset = 0;
 
             var chunkIndex = 1;
-            var totalChunks = fileSizeBytes / chunkSizeBytes + 1;
+            var totalChunks = (fileSizeBytes + chunkSizeBytes - 1) / chunkSizeBytes;
 
             if (!q)
             {


### PR DESCRIPTION
Total number of chunks was off by one when file size was exactly the size of n*chunk.

E.g. file has exactly 512MB (5*1024*1024 bytes), the following message was shown:
`Searching 2 chunks (512 MB each) across 512 MB in 'C:\Users\...`

**Notes**
Since program logic does not rely on the calculated number of chunks and uses the number of remaining bytes instead, this change fixes more an optical issue.


Following code might help to validate:
```
long fileSizeBytes = 0;
int chunkSizeBytes = 512 * 1024 * 1024;

int prevC = -1;


while (true)
{
    // long form
    var remainder = (long)0;
    var totalChunks2 = Math.DivRem(fileSizeBytes, chunkSizeBytes, out remainder);
    if (remainder > 0)
        totalChunks2++;

    // short form used in the pull request
    var totalChunks1 = (int)((fileSizeBytes + chunkSizeBytes - 1) / chunkSizeBytes);

    // original form in code
    var totalChunks3 = fileSizeBytes / chunkSizeBytes + 1;

    if (totalChunks1 != totalChunks2)
        Debugger.Break();

    if (totalChunks1 != totalChunks3)
        Debugger.Break();

    if (totalChunks1 != prevC)
    {
        Console.WriteLine($"{totalChunks1} starting at {fileSizeBytes} bytes");
        prevC = totalChunks1;
    }

    fileSizeBytes++;
}

```